### PR TITLE
graceful stop

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 ARG FLEXIBEE_DEB
 
 # instalace zakladnich balicku
-RUN apt update && apt install -y wget gnupg locales locales-all supervisor apt-transport-https gpg cron
+RUN apt update && apt install -y wget gnupg locales locales-all supervisor apt-transport-https gpg cron procps
 RUN wget -qO - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 RUN echo "deb http://apt.postgresql.org/pub/repos/apt bookworm-pgdg main" > /etc/apt/sources.list.d/pgdg.list
 
@@ -31,6 +31,8 @@ COPY postgresql-flexibee.conf /etc/postgresql/13/flexibee/conf.d/postgresql-flex
 COPY flexibee-server.xml /etc/flexibee/flexibee-server.xml
 COPY pg_hba.conf /etc/postgresql/13/flexibee/pg_hba.conf
 COPY cron-backup /etc/cron.d/cron-backup
+COPY on-stop.sh /
+RUN chmod +x /on-stop.sh
 # smazeme defaultni PostgreSQL cluster, k nicemu ho nepotrebujeme
 RUN rm -rf /etc/postgresql/13/main
 RUN apt clean
@@ -39,4 +41,4 @@ RUN rm -rf ./$FLEXIBEE_DEB
 
 EXPOSE 5434
 
-CMD ["/usr/bin/supervisord"]
+CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/supervisord.conf"]

--- a/on-stop.sh
+++ b/on-stop.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+function stop_flexibee {
+  /etc/init.d/flexibee stop
+  /etc/init.d/postgresql stop
+  exit 0
+}
+
+trap stop_flexibee SIGTERM
+
+while true; do
+  sleep 1
+done

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,8 +1,14 @@
 [supervisord]
 nodaemon=true
+user=root
 
 [program:flexibee]
 command=/etc/init.d/flexibee start
+startsecs=0
 
 [program:cron]
 command=/etc/init.d/cron start
+startsecs=0
+
+[program:on-stop]
+command=/on-stop.sh


### PR DESCRIPTION
SIGTERM listener, pred stopnutim kontajnera zastavi flexibee a postgresql. Plus male fixy:

- spustenie cron, v kontajner logu `INFO gave up: cron entered FATAL state, too many start retries too quickly`
  - supervisord.conf: pridane startsecs=0
- tiez v kontajner logu `CRIT Supervisor is running as root.  Privileges were not dropped because no user is specified in the config file.  If you intend to run as root, you can set user=root in the config file to avoid this message.`
  - supervisord.conf: user=root
  - Dockerfile: do CMD supervisord config path
- `/etc/init.d/flexibee stop ... ps: prikaz nenalezen`
  - pridany procps package